### PR TITLE
drop restify-clients dep, use restify.createJsonClient

### DIFF
--- a/lib/kang.js
+++ b/lib/kang.js
@@ -11,7 +11,6 @@ var mod_url = require('url');
 var mod_jsprim = require('jsprim');
 var mod_vasync = require('vasync');
 var mod_restify = require('restify');
-var mod_restify_clients = require('restify-clients');
 
 var mod_nutil = require('./nodeutil');
 
@@ -270,7 +269,7 @@ function knFetch(source, clientOptions, path, callback)
 			options[k] = clientOptions[k];
 	}
 
-	client = mod_restify_clients.createJsonClient(options);
+	client = mod_restify.createJsonClient(options);
 
 	client.get(path, function (err, request, response, obj) {
 		if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kang",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "debugging for distributed systems",
 	"main": "./lib/kang.js",
 	"bin": {
@@ -14,7 +14,6 @@
 		"jsprim": "^1.4.0",
 		"posix-getopt": "^1.2.0",
 		"restify": "4.1.1",
-		"restify-clients": "1.1.1",
 		"strsplit": "^1.0.0",
 		"vasync": "^1.6.4",
 		"verror": "^1.9.0"


### PR DESCRIPTION
Originally this was added in #1 to get a newer restify-clients that
supported the requestTimeout client option. Since then the *restify*
dep was updated to a ver (4.x) that supports these options with its
'restify.createJsonClient'.